### PR TITLE
add paging to file list

### DIFF
--- a/client/js/components/hyperdrive/client.js
+++ b/client/js/components/hyperdrive/client.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var yofs = require('yo-fs')
 
-module.exports = function ui (root, entries, onclick) {
+module.exports = function ui (root, entries, opts, onclick) {
   var lookup = {}
   for (var i in entries) {
     var entry = entries[i]
@@ -16,6 +16,6 @@ module.exports = function ui (root, entries, onclick) {
     }
   }
   var vals = Object.keys(lookup).map(key => lookup[key])
-  var tree = yofs(root, vals, onclick)
+  var tree = yofs(root, vals, opts, onclick)
   return tree.widget
 }

--- a/client/js/components/hyperdrive/index.js
+++ b/client/js/components/hyperdrive/index.js
@@ -5,15 +5,21 @@ module.exports = function (state, prev, send) {
   if (!module.parent && !state.archive.instance && state.archive.key) {
     send('archive:create', state.archive.key)
   }
-  var onclick = (ev, entry) => {
-    if (entry.type === 'directory') {
-      send('archive:update', {root: entry.name})
+  var onclick = (ev, entry, opts) => {
+    if (ev.target.classList.contains('pagination')) {
+      send('archive:update', opts)
+      return // TODO: what does return do here
+    } else if (entry.type === 'directory') {
+      send('archive:update', {root: entry.name, offset: 0})
       return true
     } else {
       send('preview:file', {archiveKey: state.archive.key, entry: entry}, noop)
       return false
     }
   }
-
-  return hyperdriveRenderer(state.archive.root, state.archive.entries, onclick)
+  var opts = {
+    offset: state.archive.offset,
+    limit: state.archive.limit
+  }
+  return hyperdriveRenderer(state.archive.root, state.archive.entries, opts, onclick)
 }

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -40,7 +40,9 @@ var defaultState = {
   uploadTotal: 0,
   downloadMeter: null,
   downloadSpeed: 0,
-  downloadTotal: 0
+  downloadTotal: 0,
+  offset: 0,
+  limit: 5
 }
 
 module.exports = {


### PR DESCRIPTION
Starts adding paging to file list. Depends on [yo-fs PR](https://github.com/karissa/yo-fs/pull/9). Currently looks like this:

![screen shot 2017-01-11 at 12 19 10](https://cloud.githubusercontent.com/assets/684965/21864777/32417c5c-d7f8-11e6-9caa-a57a609de06a.png)

Much style!

Notes:
- I set the current page limit to 5 for easier testing. We can increase this before merging.
- Has prev/next buttons to control paging.

TODO: 
- [ ] Merge yo-fs PR
- [ ] Figure out how to style