### PR TITLE
add json resp to root username/dat request

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -80,6 +80,11 @@ module.exports = function (opts, db) {
 
   router.get('/:username/:dataset', function (req, res) {
     db.queries.getDatByShortname(req.params, function (err, dat) {
+      var contentType = req.accepts(['html', 'json'])
+      if (contentType === 'json') {
+        if (err) return res.status(400).json({statusCode: 400, message: err.message})
+        return res.status(200).json(dat)
+      }
       if (err) {
         var state = getDefaultAppState()
         state.archive.error = {message: err.message}

--- a/tests/unit/api.js
+++ b/tests/unit/api.js
@@ -9,7 +9,8 @@ const Dat = require('dat-js')
 
 const dat = new Dat()
 
-var api = 'http://localhost:' + config.port + '/api/v1'
+var rootUrl = 'http://localhost:' + config.port
+var api = rootUrl + '/api/v1'
 test('api', function (t) {
   config.db.connection.filename = path.join(__dirname, 'test-api.sqlite')
   helpers.server(config, function (db, close) {
@@ -216,6 +217,22 @@ test('api', function (t) {
       client.secureRequest({url: '/' + users.joe.username + '/' + dats.cats.name, json: true}, function (err, resp, user) {
         t.ifError(err)
         t.same(user.name, dats.cats.name, 'is the right dat')
+        t.end()
+      })
+    })
+
+    test('api can get a dat by username/dataset combo without login', function (t) {
+      request({url: rootUrl + '/' + users.joe.username + '/' + dats.cats.name, json: true}, function (err, resp, body) {
+        t.ifError(err)
+        t.same(body.statusCode, 200)
+        t.end()
+      })
+    })
+
+    test('rootUrl json request can get a dat by username/dataset combo without login', function (t) {
+      request({url: rootUrl + '/' + users.joe.username + '/' + dats.cats.name, json: true}, function (err, resp, body) {
+        t.ifError(err)
+        t.same(body.statusCode, 200)
         t.end()
       })
     })

--- a/tests/unit/api.js
+++ b/tests/unit/api.js
@@ -224,15 +224,7 @@ test('api', function (t) {
     test('api can get a dat by username/dataset combo without login', function (t) {
       request({url: rootUrl + '/' + users.joe.username + '/' + dats.cats.name, json: true}, function (err, resp, body) {
         t.ifError(err)
-        t.same(body.statusCode, 200)
-        t.end()
-      })
-    })
-
-    test('rootUrl json request can get a dat by username/dataset combo without login', function (t) {
-      request({url: rootUrl + '/' + users.joe.username + '/' + dats.cats.name, json: true}, function (err, resp, body) {
-        t.ifError(err)
-        t.same(body.statusCode, 200)
+        t.same(body.url, dats.cats.url, 'has url')
         t.end()
       })
     })


### PR DESCRIPTION
Adds the json response to datproject.org/user/dataset. 

Was having trouble with the old tests not passing. Can debug a bit later but it seemed like maybe related to township/appa change. 

TODO:

- [x] check if new tests pass.